### PR TITLE
Add tests for the semantics feature

### DIFF
--- a/docs/usage/misc/semantics.md
+++ b/docs/usage/misc/semantics.md
@@ -1,0 +1,73 @@
+---
+layout: default
+title: Semantics
+nav_order: 2
+has_children: false
+parent: Misc
+grand_parent: Usage
+---
+
+# Semantics
+
+OpenHAB supports a [semantic model](https://www.openhab.org/docs/tutorial/model.html)
+to help you define relationships between items. Several
+[helper methods](https://www.rubydoc.info/gems/openhab-scripting/OpenHAB/DSL/Items/Semantics)
+are defined on items in order to easily navigate this model in your scripts.
+This can be extremely useful to find related items in rules that are executed
+for any member of a group. Here are a few examples:
+
+## Find the switch item for a scene channel on a zwave dimmer
+
+switches.items
+```
+Group gFullOn
+
+Group eGarageLights "Garage Lights" (lGarage) [ "Lightbulb" ]
+Dimmer GarageLights_Dimmer "Garage Lights" <light> (eGarageLights) [ "Switch" ]
+Number GarageLights_Scene "Scene" (eGarageLights, gFullOn)
+
+Group eMudLights "Mud Room Lights" (lMud) [ "Lightbulb" ]
+Dimmer MudLights_Dimmer "Garage Lights" <light> (eMudLights) [ "Switch" ]
+Number MudLights_Scene "Scene" (eMudLights, gFullOn)
+```
+
+switches.rb
+```ruby
+rule "turn dimmer to full on when switch double-tapped up" do
+  changed gFullOn.members, to: 1.3
+  run do |event|
+    dimmer_item = event.item.points(Semantics::Switch).first
+    dimmer_item.ensure << 100
+  end
+end
+```
+
+## Turn off all the lights in a room
+
+```
+Group gRoomOff
+
+Group eGarageLights "Garage Lights" (lGarage) [ "Lightbulb" ]
+Dimmer GarageLights_Dimmer "Garage Lights" <light> (eGarageLights) [ "Switch" ]
+Number GarageLights_Scene "Scene" (eGarageLights, gRoomOff)
+
+Group eMudLights "Mud Room Lights" (lGarage) [ "Lightbulb" ]
+Dimmer MudLights_Dimmer "Garage Lights" <light> (eMudLights) [ "Switch" ]
+Number MudLights_Scene "Scene" (eMudLights)
+```
+
+switches.rb
+```ruby
+rule "turn off all lights in the room when switch double-tapped down" do
+  changed gRoomOff.members, to: 2.3
+  run do |event|
+    event
+      .item
+      .location
+      .equipments(Semantics::Lightbulb)
+      .flat_map(&:members)
+      .points(Semantics::Switch)
+      .ensure.off
+  end
+end
+```

--- a/features/semantics.feature
+++ b/features/semantics.feature
@@ -1,0 +1,128 @@
+Feature: semantics
+  Rule languages supports openHAB's semantics model
+
+  Background:
+    Given Clean OpenHAB with latest Ruby Libraries
+    And groups:
+      | name                   | groups                | tags                 |
+      | gMyGroup               |                       |                      |
+      | gOutdoor               |                       | Outdoor              |
+      | gPatio                 | gOutdoor              | Patio                |
+      | Patio_Light_Bulb       | gPatio                | Lightbulb            |
+      | gIndoor                |                       | Indoor               |
+      | gLivingRoom            | gIndoor               | LivingRoom           |
+      | LivingRoom_Light1_Bulb | gLivingRoom, gMyGroup | Lightbulb            |
+      | LivingRoom_Light2_Bulb | gLivingRoom           | Lightbulb, CustomTag |
+    And items:
+      | type   | name                         | groups                 | tags                      |
+      | Switch | NoSemantic                   |                        |                           |
+      | Dimmer | Patio_Light_Brightness       | Patio_Light_Bulb       | Control,Level             |
+      | Color  | Patio_Light_Color            | Patio_Light_Bulb       | Control,Light             |
+      | Switch | Patio_Motion                 | gPatio                 | MotionDetector, CustomTag |
+      | Dimmer | LivingRoom_Light1_Brightness | LivingRoom_Light1_Bulb | Control,Level             |
+      | Color  | LivingRoom_Light1_Color      | LivingRoom_Light1_Bulb | Control,Light             |
+      | Dimmer | LivingRoom_Light2_Brightness | LivingRoom_Light2_Bulb | Control,Level             |
+      | Color  | LivingRoom_Light2_Color      | LivingRoom_Light2_Bulb | Control,Light             |
+      | Switch | LivingRoom_Motion            | gLivingRoom            | MotionDetector            |
+
+  Scenario Outline: Items have semantics methods
+    Given code in a rules file
+      """
+      begin
+        logger.info("Item <item>.<method>: #{<item>.<method>}")
+      rescue => e
+        logger.error("Item <item>.<method>: Exception caught: #{e.message}")
+      end
+      """
+    When I deploy the rules file
+    Then It should log 'Item <item>.<method>: <result>' within 5 seconds
+    Examples: Valid values
+      | item                   | method                                                  | result                                          |
+      | gIndoor                | location?                                               | true                                            |
+      | gIndoor                | equipment?                                              | false                                           |
+      | gIndoor                | point?                                                  | false                                           |
+      | NoSemantic             | semantic?                                               | false                                           |
+      | Patio_Light_Bulb       | semantic?                                               | true                                            |
+      | Patio_Light_Bulb       | equipment?                                              | true                                            |
+      | Patio_Motion           | equipment?                                              | true                                            |
+      | Patio_Light_Bulb       | location.name                                           | gPatio                                          |
+      | Patio_Light_Bulb       | location_type == Semantics::Patio                       | true                                            |
+      | Patio_Light_Bulb       | equipment_type == Semantics::Lightbulb                  | true                                            |
+      | Patio_Light_Brightness | point_type == Semantics::Control                        | true                                            |
+      | Patio_Light_Brightness | property_type == Semantics::Level                       | true                                            |
+      | Patio_Light_Brightness | equipment.name                                          | Patio_Light_Bulb                                |
+      | Patio_Light_Brightness | equipment_type == Semantics::Lightbulb                  | true                                            |
+      | Patio_Light_Brightness | semantic_type == Semantics::Control                     | true                                            |
+      | Patio_Light_Brightness | points.map(&:name)                                      | ["Patio_Light_Color"]                           |
+      | Patio_Light_Bulb       | points.map(&:name).sort                                 | ["Patio_Light_Brightness", "Patio_Light_Color"] |
+      | Patio_Light_Bulb       | points(Semantics::Light).first.name                     | Patio_Light_Color                               |
+      | Patio_Light_Bulb       | points(Semantics::Level).first.name                     | Patio_Light_Brightness                          |
+      | Patio_Light_Bulb       | points(Semantics::Level, Semantics::Control).first.name | Patio_Light_Brightness                          |
+    Examples: #points with invalid arguments
+      | item             | method                                                        | result            |
+      | Patio_Light_Bulb | points(Semantics::Level, Semantics::Indoor)                   | Exception caught: |
+      | Patio_Light_Bulb | points(Semantics::Lightbulb)                                  | Exception caught: |
+      | Patio_Light_Bulb | points(Semantics::Indoor)                                     | Exception caught: |
+      | Patio_Light_Bulb | points(Semantics::Level, Semantics::Light)                    | Exception caught: |
+      | Patio_Light_Bulb | points(Semantics::Switch, Semantics::Control)                 | Exception caught: |
+      | Patio_Light_Bulb | points(Semantics::Switch, Semantics::Light, Semantics::Level) | Exception caught: |
+
+  Scenario Outline: Enumerable has semantics methods
+    Given code in a rules file
+      """
+      begin
+        logger.info(%Q[Item <item>.<method>: #{<item>.<method>}])
+      rescue => e
+        logger.error(%Q[Item <item>.<method>: Exception caught: #{e.message}])
+      end
+      """
+    When I deploy the rules file
+    Then It should log 'Item <item>.<method>: <result>' within 5 seconds
+    Examples: Enumerable methods
+      | item        | method                                               | result                                               |
+      | gPatio      | equipments.map(&:name).sort                          | ["Patio_Light_Bulb", "Patio_Motion"]                 |
+      | gIndoor     | sublocations.map(&:name).sort                        | ["gLivingRoom"]                                      |
+      | gIndoor     | sublocations(Semantics::Room).map(&:name).sort       | ["gLivingRoom"]                                      |
+      | gIndoor     | sublocations(Semantics::LivingRoom).map(&:name).sort | ["gLivingRoom"]                                      |
+      | gIndoor     | sublocations(Semantics::FamilyRoom).map(&:name).sort | []                                                   |
+      | gIndoor     | sublocations(Semantics::Light).map(&:name).sort      | Exception caught:                                    |
+      | items       | tagged("CustomTag").map(&:name).sort                 | ["LivingRoom_Light2_Bulb", "Patio_Motion"]           |
+      | gLivingRoom | tagged("Lightbulb").map(&:name).sort                 | ["LivingRoom_Light1_Bulb", "LivingRoom_Light2_Bulb"] |
+      | gLivingRoom | not_tagged("Lightbulb").map(&:name).sort             | ["LivingRoom_Motion"]                                |
+      | gLivingRoom | members.member_of(gMyGroup).map(&:name).sort         | ["LivingRoom_Light1_Bulb"]                           |
+      | gLivingRoom | members.not_member_of(gMyGroup).map(&:name).sort     | ["LivingRoom_Light2_Bulb", "LivingRoom_Motion"]      |
+    Examples: Chaining methods
+      | item              | method                                                                | result                     |
+      | LivingRoom_Motion | location.not_member_of(gMyGroup).tagged("CustomTag").map(&:name).sort | ["LivingRoom_Light2_Bulb"] |
+      | LivingRoom_Motion | location.equipments.tagged("CustomTag").map(&:name).sort              | ["LivingRoom_Light2_Bulb"] |
+
+  Scenario Outline: Enumerable supports points
+    Given code in a rules file
+      """
+      begin
+        points = <item>.equipments
+                       .flat_map { |e| e.respond_to?(:members) ? e.members : e }
+                       .points(<args>)
+                       .map(&:name)
+                       .sort
+
+        logger.info("Item points(<args>): #{points}")
+      rescue => e
+        logger.error("Item points(<args>): Exception caught: #{e.message}")
+      end
+      """
+    When I deploy the rules file
+    Then It should log 'Item points(<args>): <result>' within 5 seconds
+    Examples: Valid arguments
+      | item   | args                                 | result                                          |
+      | gPatio |                                      | ["Patio_Light_Brightness", "Patio_Light_Color"] |
+      | gPatio | Semantics::Control                   | ["Patio_Light_Brightness", "Patio_Light_Color"] |
+      | gPatio | Semantics::Light                     | ["Patio_Light_Color"]                           |
+      | gPatio | Semantics::Light, Semantics::Control | ["Patio_Light_Color"]                           |
+    Examples: Invalid arguments
+      | item   | args                                  | result            |
+      | gPatio | Semantics::Light, Semantics::Level    | Exception caught: |
+      | gPatio | Semantics::Room                       | Exception caught: |
+      | gPatio | Semantics::Control, Semantics::Switch | Exception caught: |
+
+

--- a/features/support/openhab.rb
+++ b/features/support/openhab.rb
@@ -6,7 +6,8 @@ require 'singleton'
 require 'tty-command'
 require 'fileutils'
 
-Item = Struct.new(:type, :name, :state, :label, :groups, :group_type, :pattern, :function, :params, keyword_init: true)
+Item = Struct.new(:type, :name, :state, :label, :tags, :groups, :group_type, :pattern, :function, :params,
+                  keyword_init: true)
 
 def openhab_dir
   File.realpath 'tmp/openhab'

--- a/features/support/openhab_rest.rb
+++ b/features/support/openhab_rest.rb
@@ -80,6 +80,7 @@ class Rest
     body[:type] = item.type
     body[:name] = item.name
     body[:label] = item.label if item.label && item.label.strip != ''
+    item_tags(body, item)
     item_groups(body, item)
     body
   end
@@ -100,6 +101,10 @@ class Rest
     function_body[:name] = item.function
     function_body[:params] = item.params if item.params
     body[:function] = function_body
+  end
+
+  def self.item_tags(body, item)
+    body[:tags] = item.tags unless item.tags.nil? || item.tags.empty?
   end
 
   def self.item_groups(body, item)

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -99,6 +99,7 @@ module OpenHAB
     module Items
       GenericItem.prepend(OpenHAB::DSL::Ensure::GenericItem)
       GroupItem::GroupMembers.include(OpenHAB::DSL::Ensure::Ensurable)
+      Enumerable.include(OpenHAB::DSL::Ensure::Ensurable)
     end
   end
 end

--- a/lib/openhab/dsl/items/ensure.rb
+++ b/lib/openhab/dsl/items/ensure.rb
@@ -73,6 +73,13 @@ module OpenHAB
           @item = item
         end
 
+        # @!visibility private
+        # this is explicitly defined, instead of aliased, because #command
+        # doesn't actually exist as a method, and will go through method_missing
+        def <<(command)
+          command(command)
+        end
+
         # activate +ensure_states+ before forwarding to the wrapped object
         def method_missing(method, *args, &block)
           return super unless @item.respond_to?(method)

--- a/lib/openhab/dsl/items/enumerable.rb
+++ b/lib/openhab/dsl/items/enumerable.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# Additions to Enumerable to allow easily filtering and commanding groups of items
+module Enumerable
+  # Returns a new array of items that have at least one of the given tags
+  def tagged(*tags)
+    reject { |i| (tags & i.tags.to_a).empty? }
+  end
+
+  # Returns a new array of items that do not have any of the given tags
+  def not_tagged(*tags)
+    select { |i| (tags & i.tags.to_a).empty? }
+  end
+
+  # Returns a new array of items that are a member of at least one of the given groups
+  def member_of(*groups)
+    reject { |i| (groups.map(&:name) & i.group_names).empty? }
+  end
+
+  # Returns a new array of items that are not a member of any of the given groups
+  def not_member_of(*groups)
+    select { |i| (groups.map(&:name) & i.group_names).empty? }
+  end
+
+  # Send a command to every item in the collection
+  def command(command)
+    each { |i| i.command(command) }
+  end
+
+  # Update the state of every item in the collection
+  def update(state)
+    each { |i| i.update(state) }
+  end
+
+  # @!method refresh
+  #   Send the +REFRESH+ command to every item in the collection
+
+  # @!method on
+  #   Send the +ON+ command to every item in the collection
+
+  # @!method off
+  #   Send the +OFF+ command to every item in the collection
+
+  # @!method up
+  #   Send the +UP+ command to every item in the collection
+
+  # @!method down
+  #   Send the +DOWN+ command to every item in the collection
+
+  # @!method stop
+  #   Send the +STOP+ command to every item in the collection
+
+  # @!method move
+  #   Send the +MOVE+ command to every item in the collection
+
+  # @!method increase
+  #   Send the +INCREASE+ command to every item in the collection
+
+  # @!method decrease
+  #   Send the +DECREASE+ command to every item in the collection
+
+  # @!method play
+  #   Send the +PLAY+ command to every item in the collection
+
+  # @!method pause
+  #   Send the +pause+ command to every item in the collection
+
+  # @!method rewind
+  #   Send the +REWIND+ command to every item in the collection
+
+  # @!method fast_forward
+  #   Send the +FAST_FORWARD+ command to every item in the collection
+
+  # @!method next
+  #   Send the +NEXT+ command to every item in the collection
+
+  # @!method previous
+  #   Send the +PREVIOUS+ command to every item in the collection
+
+  # @!visibility private
+  # can't use `include`, because Enumerable has already been included
+  # in other classes
+  def ensure
+    OpenHAB::DSL::Items::Ensure::GenericItemDelegate.new(self)
+  end
+end

--- a/lib/openhab/dsl/items/generic_item.rb
+++ b/lib/openhab/dsl/items/generic_item.rb
@@ -2,6 +2,7 @@
 
 require 'openhab/dsl/items/metadata'
 require 'openhab/dsl/items/persistence'
+require 'openhab/dsl/items/semantics'
 
 require_relative 'item_equality'
 
@@ -10,14 +11,17 @@ module OpenHAB
     module Items
       java_import org.openhab.core.items.GenericItem
 
-      # Adds methods to core OpenHAB DimmerItem type to make it more natural in
+      # Adds methods to core OpenHAB GenericItem type to make it more natural in
       # Ruby
+      #
+      # @see https://www.openhab.org/javadoc/latest/org/openhab/core/items/genericitem
       class GenericItem
         include Log
         include ItemEquality
 
         prepend Metadata
         prepend Persistence
+        include Semantics
 
         # rubocop:disable Naming/MethodName these mimic Java fields, which are
         # actually methods

--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -47,6 +47,17 @@ module OpenHAB
 
         remove_method :==
 
+        # Override Enumerable because we want to send them to the base item if possible
+        #
+        # @return [GroupMembers] +self+
+        %i[command update].each do |method|
+          define_method(method) do |command|
+            return base_item.__send__(method, command) if base_item
+
+            super(command)
+          end
+        end
+
         #
         # Get an Array-like object representing the members of the group
         #
@@ -87,10 +98,6 @@ module OpenHAB
           end
         end
 
-        # don't want to inherit these from Enumerable, because we want to send them to the base item
-        remove_method %i[ensure refresh on off up down stop move increase decrease play pause rewind fast_forward next
-                         previous]
-
         # Delegate missing methods to +base_item+ if possible
         def method_missing(method, *args, &block)
           return base_item.__send__(method, *args, &block) if base_item.respond_to?(method)
@@ -105,6 +112,7 @@ module OpenHAB
           super
         end
 
+        # Is this ever called?
         # give the base item type a chance to format commands
         # @!visibility private
         def format_type(command)

--- a/lib/openhab/dsl/items/group_item.rb
+++ b/lib/openhab/dsl/items/group_item.rb
@@ -39,73 +39,7 @@ module OpenHAB
             group.name
           end
 
-          # Send a command to each member of the group
-          #
-          # @return [GroupMembers] +self+
-          def command(command)
-            each { |item| item << command }
-          end
           alias << command
-
-          # @!method refresh
-          #   Send the +REFRESH+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method on
-          #   Send the +ON+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method off
-          #   Send the +OFF+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method up
-          #   Send the +UP+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method down
-          #   Send the +DOWN+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method stop
-          #   Send the +STOP+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method move
-          #   Send the +MOVE+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method increase
-          #   Send the +INCREASE+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method desrease
-          #   Send the +DECREASE+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method play
-          #   Send the +PLAY+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method pause
-          #   Send the +PAUSE+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method rewind
-          #   Send the +REWIND+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method fast_forward
-          #   Send the +FASTFORWARD+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method next
-          #   Send the +NEXT+ command to each member of the group
-          #   @return [GroupMembers] +self+
-
-          # @!method previous
-          #   Send the +PREVIOUS+ command to each member of the group
-          #   @return [GroupMembers] +self+
         end
 
         include Enumerable
@@ -152,6 +86,10 @@ module OpenHAB
             get_all_members.to_a
           end
         end
+
+        # don't want to inherit these from Enumerable, because we want to send them to the base item
+        remove_method %i[ensure refresh on off up down stop move increase decrease play pause rewind fast_forward next
+                         previous]
 
         # Delegate missing methods to +base_item+ if possible
         def method_missing(method, *args, &block)

--- a/lib/openhab/dsl/items/items.rb
+++ b/lib/openhab/dsl/items/items.rb
@@ -76,6 +76,13 @@ module OpenHAB
               end                   # end
             RUBY
 
+            # Override the inherited methods from Enumerable and send it to the base_item
+            GroupItem.class_eval <<~RUBY, __FILE__, __LINE__ + 1
+              def #{command}                 # def on
+                method_missing(:#{command})  #   method_missing(:on)
+              end                            # end
+            RUBY
+
             logger.trace("Defining ItemCommandEvent##{command}? for #{value}")
             MonkeyPatch::Events::ItemCommandEvent.class_eval <<~RUBY, __FILE__, __LINE__ + 1
               def #{command}?        # def refresh?

--- a/lib/openhab/dsl/items/items.rb
+++ b/lib/openhab/dsl/items/items.rb
@@ -69,8 +69,8 @@ module OpenHAB
               end                                                                                       # end
             RUBY
 
-            logger.trace("Defining GroupItem::GroupMembers##{command} for #{value}")
-            GroupItem::GroupMembers.class_eval <<~RUBY, __FILE__, __LINE__ + 1
+            logger.trace("Defining Enumerable##{command} for #{value}")
+            Enumerable.class_eval <<~RUBY, __FILE__, __LINE__ + 1
               def #{command}        # def on
                 each(&:#{command})  #   each(&:on)
               end                   # end

--- a/lib/openhab/dsl/items/semantics.rb
+++ b/lib/openhab/dsl/items/semantics.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'enumerable'
+require_relative 'semantics/enumerable'
 
 module OpenHAB
   module DSL
@@ -86,7 +86,7 @@ module OpenHAB
       #
       # @return [Class]
       def location_type
-        SemanticsAction.get_location_type(Self)&.ruby_class
+        SemanticsAction.get_location_type(self)&.ruby_class
       end
 
       # Gets the related Equipment Item of this Item.
@@ -168,8 +168,6 @@ module OpenHAB
         members.points(*point_or_property_types)
       end
     end
-
-    GenericItem.include(Semantics)
   end
 end
 
@@ -204,7 +202,7 @@ module Enumerable
   #   lGreatRoom.equipments.flat_map(&:members).points(Semantics::Switch)
   def points(*point_or_property_types) # rubocop:disable Metrics
     unless (0..2).cover?(point_or_property_types.length)
-      raise ArgumentError, "wrong number of arguments (given #{point_or_property_types.length}, expected 1..2)"
+      raise ArgumentError, "wrong number of arguments (given #{point_or_property_types.length}, expected 0..2)"
     end
     unless point_or_property_types.all? do |tag|
              tag < OpenHAB::DSL::Semantics::Point || tag < OpenHAB::DSL::Semantics::Property
@@ -220,8 +218,8 @@ module Enumerable
       next unless point.point?
 
       point_or_property_types.all? do |tag|
-        (tag < OpenHAB::DSL::Semantics::Point && point.point_type <= tag) ||
-          (tag < OpenHAB::DSL::Semantics::Property && point.property_type <= tag)
+        (tag < OpenHAB::DSL::Semantics::Point && point.point_type&.<=(tag)) ||
+          (tag < OpenHAB::DSL::Semantics::Property && point.property_type&.<=(tag))
       end
     end
   end

--- a/lib/openhab/dsl/items/semantics.rb
+++ b/lib/openhab/dsl/items/semantics.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require_relative 'enumerable'
+
+module OpenHAB
+  module DSL
+    # Module for implementing semantics helper methods on [GenericItem]
+    #
+    # Wraps https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/semantics,
+    # as well as adding a few additional convenience methods.
+    # Also includes Classes for each semantic tag.
+    #
+    # Be warned that the Semantic model is stricter than can actually be
+    # described by tags and groups on an Item. It makes assumptions that any
+    # given item only belongs to one semantic type (Location, Equipment, Point).
+    #
+    # See https://github.com/openhab/openhab-core/blob/main/bundles/org.openhab.core.semantics/model/SemanticTags.csv
+    module Semantics
+      # @!visibility private
+      # import the actual semantics action
+      SemanticsAction = org.openhab.core.model.script.actions.Semantics
+      private_constant :SemanticsAction
+
+      # import all the semantics constants
+      [org.openhab.core.semantics.model.point.Points,
+       org.openhab.core.semantics.model.property.Properties,
+       org.openhab.core.semantics.model.equipment.Equipments,
+       org.openhab.core.semantics.model.location.Locations].each do |parent_tag|
+        parent_tag.stream.for_each do |tag|
+          const_set(tag.simple_name.to_sym, tag.ruby_class)
+        end
+      end
+
+      # put ourself into the global namespace, replacing the action
+      ::Semantics = self # rubocop:disable Naming/ConstantName
+
+      # Checks if this Item is a Location
+      #
+      # This is implemented as checking if the item's semantic_type
+      # is a Location. I.e. an Item has a single semantic_type.
+      #
+      # @return [true, false]
+      def location?
+        SemanticsAction.location?(self)
+      end
+
+      # Checks if this Item is an Equipment
+      #
+      # This is implemented as checking if the item's semantic_type
+      # is an Equipment. I.e. an Item has a single semantic_type.
+      #
+      # @return [true, false]
+      def equipment?
+        SemanticsAction.equipment?(self)
+      end
+
+      # Checks if this Item is a Point
+      #
+      # This is implemented as checking if the item's semantic_type
+      # is a Point. I.e. an Item has a single semantic_type.
+      #
+      # @return [true, false]
+      def point?
+        SemanticsAction.point?(self)
+      end
+
+      # Checks if this Item has any semantic tags
+      # @return [true, false]
+      def semantic?
+        !!semantic_type
+      end
+
+      # Gets the related Location Item of this Item.
+      #
+      # Returns +self+ if this Item is a Location. Otherwise, checks ancestor
+      # groups one level at a time, returning the first Location Item found.
+      #
+      # @return [GenericItem, nil]
+      def location
+        SemanticsAction.get_location(self)
+      end
+
+      # Returns the sub-class of [Location] related to this Item.
+      #
+      # In other words, the semantic_type of this Item's Location.
+      #
+      # @return [Class]
+      def location_type
+        SemanticsAction.get_location_type(Self)&.ruby_class
+      end
+
+      # Gets the related Equipment Item of this Item.
+      #
+      # Returns +self+ if this Item is an Equipment. Otherwise, checks ancestor
+      # groups one level at a time, returning the first Equipment Item found.
+      #
+      # @return [GenericItem, nil]
+      def equipment
+        SemanticsAction.get_equipment(self)
+      end
+
+      # Returns the sub-class of [Equipment] related to this Item.
+      #
+      # In other words, the semantic_type of this Item's Equipment.
+      #
+      # @return [Class]
+      def equipment_type
+        SemanticsAction.get_equipment_type(self)&.ruby_class
+      end
+
+      # Returns the sub-class of [Point] this Item is tagged with.
+      #
+      # @return [Class]
+      def point_type
+        SemanticsAction.get_point_type(self)&.ruby_class
+      end
+
+      # Returns the sub-class of [Property] this Item is tagged with.
+      # @return [Class]
+      def property_type
+        SemanticsAction.get_property_type(self)&.ruby_class
+      end
+
+      # Returns the sub-class of [Tag] this Item is tagged with.
+      #
+      # It will only return the first applicable Tag, preferring
+      # a sub-class of [Location], [Equipment], or [Point] first,
+      # and if none of those are found, looks for a [Property].
+      # @return [Class]
+      def semantic_type
+        SemanticsAction.get_semantic_type(self)&.ruby_class
+      end
+
+      # Return the related Point Items.
+      #
+      # Searches this Equipment Item for Points that are tagged appropriately.
+      #
+      # If called on a Point Item, it will automatically search for sibling Points
+      # (and remove itself if found).
+      #
+      # @example Get all points for a TV
+      #   eGreatTV.points
+      # @example Search an Equipment item for its switch
+      #   eGuestFan.points(Semantics::Switch) # => [GuestFan_Dimmer]
+      # @example Search a Thermostat item for its current temperature item
+      #   eFamilyThermostat.points(Semantics::Status, Semantics::Temperature)
+      #   # => [FamilyThermostat_AmbTemp]
+      # @example Search a Thermostat item for is setpoints
+      #   eFamilyThermostat.points(Semantics::Control, Semantics::Temperature)
+      #   # => [FamilyThermostat_HeatingSetpoint, FamilyThermostat_CoolingSetpoint]
+      # @example Given a A/V receiver's input item, search for it's power item
+      #   FamilyReceiver_Input.points(Semantics::Switch) # => FamilyReceiver_Switch
+      #
+      # @param [Class] point_or_property_types
+      #   Pass 1 or 2 classes that are sub-classes of [Point] or [Property].
+      #   Note that when comparing against semantic tags, it does a sub-class check.
+      #   So if you search for [Control], you'll get items tagged with [Switch].
+      # @return [Array<GenericItem>]
+      def points(*point_or_property_types)
+        # automatically search the parent equipment (or location?!) for sibling points
+        unless equipment? || location?
+          result = (equipment || location)&.points(*point_or_property_types) || []
+          # remove self. but avoid state comparisons
+          result.delete_if { |item| item.eql?(self) }
+          return result
+        end
+
+        members.points(*point_or_property_types)
+      end
+    end
+
+    GenericItem.include(Semantics)
+  end
+end
+
+# Additions to Enumerable to allow easily filtering groups of items based on the semantic model
+module Enumerable
+  # Returns a new array of items that are a semantics Location (optionally of the given type)
+  def sublocations(type = nil)
+    raise ArgumentError, 'type must be a subclass of Location' if type && !(type < OpenHAB::DSL::Semantics::Location)
+
+    result = select(&:location?)
+    result.select! { |i| i.location_type <= type } if type
+
+    result
+  end
+
+  # Returns a new array of items that are a semantics equipment (optionally of the given type)
+  #
+  # @example Get all TVs in a room
+  #   lGreatRoom.equipments(Semantics::Screen)
+  def equipments(type = nil)
+    raise ArgumentError, 'type must be a subclass of Equipment' if type && !(type < OpenHAB::DSL::Semantics::Equipment)
+
+    result = select(&:equipment?)
+    result.select! { |i| i.equipment_type <= type } if type
+
+    result
+  end
+
+  # Returns a new array of items that are semantics points (optionally of a given type)
+  #
+  # @example Get all the power switch items for every equipment in a room
+  #   lGreatRoom.equipments.flat_map(&:members).points(Semantics::Switch)
+  def points(*point_or_property_types) # rubocop:disable Metrics
+    unless (0..2).cover?(point_or_property_types.length)
+      raise ArgumentError, "wrong number of arguments (given #{point_or_property_types.length}, expected 1..2)"
+    end
+    unless point_or_property_types.all? do |tag|
+             tag < OpenHAB::DSL::Semantics::Point || tag < OpenHAB::DSL::Semantics::Property
+           end
+      raise ArgumentError, 'point_or_property_types must all be a subclass of Point or Property'
+    end
+    if point_or_property_types.count { |tag| tag < OpenHAB::DSL::Semantics::Point } > 1 ||
+       point_or_property_types.count { |tag| tag < OpenHAB::DSL::Semantics::Property } > 1
+      raise ArgumentError, 'point_or_property_types cannot both be a subclass of Point or Property'
+    end
+
+    select do |point|
+      next unless point.point?
+
+      point_or_property_types.all? do |tag|
+        (tag < OpenHAB::DSL::Semantics::Point && point.point_type <= tag) ||
+          (tag < OpenHAB::DSL::Semantics::Property && point.property_type <= tag)
+      end
+    end
+  end
+end

--- a/lib/openhab/dsl/items/semantics/enumerable.rb
+++ b/lib/openhab/dsl/items/semantics/enumerable.rb
@@ -76,11 +76,4 @@ module Enumerable
 
   # @!method previous
   #   Send the +PREVIOUS+ command to every item in the collection
-
-  # @!visibility private
-  # can't use `include`, because Enumerable has already been included
-  # in other classes
-  def ensure
-    OpenHAB::DSL::Items::Ensure::GenericItemDelegate.new(self)
-  end
 end


### PR DESCRIPTION
* rebased to 4.37.1 - is there a better way to do this?
* Add the ability to create tags in cucumber tests
* Add tests for the semantics feature

This is what the PR/branch looks like against the current HEAD
https://github.com/jimtng/openhab-jruby/pull/5

- [x] Fix ensure_states.feature test
- [ ] Document the added Enumerable methods: tagged, member_of, etc 